### PR TITLE
renamed: bil-veri -> bap-veri

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ really different, since only not equal events goes to matching.
 ##Usage
 Program works only with files with `.frames` extension.
 ```
-bil-veri --show-errors --show-stat --rules "path to rules file" PATH
+bap-veri --show-errors --show-stat --rules "path to rules file" PATH
 
 `PATH` is either directory with files from a tracer, either a file.
 `show-errors` option allows to see a detailed information about BIL errors

--- a/_oasis
+++ b/_oasis
@@ -1,5 +1,5 @@
 OASISFormat:  0.4
-Name:         bil-veri
+Name:         bap-veri
 Version:      0.2
 Synopsis:     Bil verification tool
 Authors:      BAP Team
@@ -22,7 +22,7 @@ Library veri
                   Veri_stat,
                   Veri_traci
   CompiledObject: best
-  Install:        false
+  Install:        true
   NativeOpt:      -pp 'ppx-jane -dump-ast'
   ByteOpt:        -pp 'ppx-jane -dump-ast'
   BuildDepends:   pcre, textutils, threads
@@ -38,7 +38,7 @@ Library veri_test
                   Veri_stat_test
   BuildDepends:   bap-veri, oUnit
 
-Executable "bil-veri"
+Executable "bap-veri"
   Path:           src
   MainIs:         veri_main.ml
   CompiledObject: best


### PR DESCRIPTION
This PR renamed `bil-veri` to `bap-veri` and also installs a `bap-veri` library