### PR TITLE
added a bot event and using of a fresh context

### DIFF
--- a/lib/veri.mli
+++ b/lib/veri.mli
@@ -28,6 +28,7 @@ class context: Veri_stat.t -> Veri_policy.t -> Trace.t -> object('s)
     method set_code : Chunk.t -> 's 
     method set_insn: string -> 's
     method drop_pc : 's
+    method finish_step : Veri_stat.t -> 's
   end
 
 class ['a] t : arch -> Disasm.t -> object('s)


### PR DESCRIPTION
This PR introduce the next features, to make verification more strict:
1) Every instruction is evaluated in fresh context to be
   sure, that nothing from previous evaluation is used.
2) a new event, `bot_read` could emitted if `bil` code attempting
   to access a variable that doesn't bound in context

For example, consider `CMOVrr` instruction, that isn't implemented
as it should be (`else` branch must not present according to amd 
instruction set).

```
{
  RDI := if ZF then RCX else RDI
}
```

If `ZF` flag is `true` then everything is ok without any changes.
But if the flag is false then there are two possible cases here:
1) `RDI` isn't bound in context - then a fact of access to `RDI`
   will be silenced - and in this case everything will look like 
   correct, although it's not a truth.
2) `RDI` is bound, then `register_read` and `register_write` will
   be generated, and both of them won't have a pair in real events
   set. Well, in this case, we'll at least notice an error.
So, to solve a problem in question we introduce a special event,
`bot_read` that will be generated in case of failed access to 
variable or address. And we guarantee that nothing from previous 
evaluation will affect on next one. 
