### PR TITLE
minor changes in variables comparies

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # bil-verification
 
-A central goal of this tool is to find errors in our BIL code. So this tool 
+A central goal of this tool is to find errors in our BIL code. So this tool
 compares results of instructions execution in trace with execution of BIL code,
-that describes this instructions. Verification is based on comparison of two 
-set of events. First one is a real events set, that came from trace. And second 
-one is a set, that was filled during execution of `code_exec` event, by 
+that describes this instructions. Verification is based on comparison of two
+set of events. First one is a real events set, that came from trace. And second
+one is a set, that was filled during execution of `code_exec` event, by
 emitting artificial events.
 
 ##Build and install
@@ -21,39 +21,39 @@ BIL are equal to each other. But in practice both trace and bil could
 contain some special cases. For example, trace could be obtained from
 source, that does not provide some cpu flags, or bil does not support
 some instructions.  And we possible may want to shadow this cases and
-continue verification process. From other point of view, we do not want 
+continue verification process. From other point of view, we do not want
 to miss errors. So for this reasons tool supports policy, that is a set
 of rules with the following grammar.
 
 Each rule consists of 4 fields: `ACTION INSN L_EVENT R_EVENT`
 
-1. `ACTION`  field could be either `SKIP`, either `DENY`. If we have processed 
+1. `ACTION`  field could be either `SKIP`, either `DENY`. If we have processed
    trace without matching with any `DENY`, then everything is ok.
-2. `INSN`    field could contain an instruction name like `MOV64rr` or regular 
+2. `INSN`    field could contain an instruction name like `MOV64rr` or regular
    expression, like `MOV.*`
-3. `L_EVENT` field, left hand-side event, corresponds to textual representation 
-   of tracer events, and could contain any string and regualar expression. 
+3. `L_EVENT` field, left hand-side event, corresponds to textual representation
+   of tracer events, and could contain any string and regualar expression.
 4. `R_EVENT` field, right hand-side event, corresponds to textual representation
-   of lifter events, and could contain any string and regualar expression. 
+   of lifter events, and could contain any string and regualar expression.
 
 Matching is performed textually, based on event syntax. Regexp syntax supports
 backreferences in event fields. Only that events, that don't have an equal
-pair in other set goes to this matching. 
+pair in other set goes to this matching.
 
 Rules could be written in text file, that will be passed as argument through
 command line. Syntax is a pretty simple. Each row either contains a rule,
-either commented with `#` symbol, either empty. Rule must have exactly 
-4 fields. An empty field must be written as `''` or `""`. Fields with spaces 
+either commented with `#` symbol, either empty. Rule must have exactly
+4 fields. An empty field must be written as `''` or `""`. Fields with spaces
 must be written in quotes: `"RAX => .*"`, single quotes also supported:
 `'RAX => .*'`.
 
 ###Examples
 
-For example, let's imagine that a tracer doesn't support read from zero 
-flag, so all read events from zero flag in bil code will be unmatched. 
+For example, let's imagine that a tracer doesn't support read from zero
+flag, so all read events from zero flag in bil code will be unmatched.
 So we are able to create next rule :
 `SKIP .* '' 'ZF -> .*'`
-This could be read as: for any instruction skip unmatched zero flag 
+This could be read as: for any instruction skip unmatched zero flag
 reading in bil code.
 
 Next two rules means that that no one should be left without a pair.
@@ -61,8 +61,8 @@ Next two rules means that that no one should be left without a pair.
 DENY .* .* ''
 DENY .* '' .*
 ```
-That does mean that for any instruction unmatched left/right event is an error. 
-This pair is also a default behavior in case when there wasn't any policy file 
+That does mean that for any instruction unmatched left/right event is an error.
+This pair is also a default behavior in case when there wasn't any policy file
 given through a command line.
 
 Also we can use this policy to check incomplete lifter, for example we can say:
@@ -72,9 +72,9 @@ DENY MOV.* '' .*
 ```
 And check only move instructions.
 
-Backreferenses example: `DENY .* '(.F) <= .*' '\1 <= .*'`, that could be read 
-as: for any instruction complain if a value written in some flag in tracer is 
-differrent from value written in lifter for the same flag. And values are 
+Backreferenses example: `DENY .* '(.F) <= .*' '\1 <= .*'`, that could be read
+as: for any instruction complain if a value written in some flag in tracer is
+differrent from value written in lifter for the same flag. And values are
 really different, since only not equal events goes to matching.
 
 ##Usage

--- a/rules/arm_qemu
+++ b/rules/arm_qemu
@@ -1,0 +1,14 @@
+# skipping context switch events
+SKIP .* 'context-switch.*' ''
+
+SKIP .* '' '.F => .*'
+SKIP .* '' '.F <= .*'
+SKIP .* '.F <= .*' ''
+SKIP .* '.F => .*' ''
+SKIP .* 'GE <= .*' ''
+
+SKIP .* 'PC => .*' ''
+
+# Last rules means that every event should has a pair
+DENY .* '.*' ''
+DENY .* '' '.*'

--- a/rules/x86_no_errors
+++ b/rules/x86_no_errors
@@ -1,6 +1,13 @@
-# we completle ignore the following because bil is either empty, 
+# we completle ignore the following because bil is either empty,
 # either contains unknown expressions or special statements
-SKIP NOOP. '' '' 
+
+# skipping modload events
+SKIP .* '.*: .* - .*' ''
+
+# skipping context switch events
+SKIP .* 'context-switch.*' ''
+
+SKIP NOOP. '' ''
 SKIP RDTSC '' ''
 SKIP SYSCALL.* '' ''
 SKIP CPUID '' ''
@@ -12,7 +19,7 @@ SKIP XGETBV '' ''
 #differences in ZF flag writing
 SKIP TZCNT64rr 'ZF <= .*' 'ZF <= .*'
 
-# SAR is suspected to be broken in our lifter, because of different 
+# SAR is suspected to be broken in our lifter, because of different
 # results with tracer
 SKIP SAR.* '' ''
 
@@ -20,24 +27,24 @@ SKIP SAR.* '' ''
 # e.g. RAX and RAX, it reads nothing, just write zero to destination
 SKIP XOR.* '.* => .*' ''
 
-# There are a wrong flags reads in our lifter. 
+# There are a wrong flags reads in our lifter.
 SKIP SH(L|R).* '' '.F => .*'
 
 # CMOV in our lifter works a bit unstrict. It reads and writes the same value
 # if condition wasn't succeded.
 SKIP CMOV.* '' '.*'
 
-# insn contains a conditional branch. As a result, in tracer, 
-# if a condition is not satisfied then the same value 
+# insn contains a conditional branch. As a result, in tracer,
+# if a condition is not satisfied then the same value
 # is written (the same as was read).
 SKIP CMPXCHG.* '.* <= .*' ''
 
 # LEAVE insn has additional read from RSP in our tracer
 SKIP LEAVE.* 'RSP => .*' ''
 
-# Our flags reads(writes) should be subset of tracer 
+# Our flags reads(writes) should be subset of tracer
 # reads(writes). But writes should be with same value
-SKIP .* '.F => .*' '' 
+SKIP .* '.F => .*' ''
 DENY .* '(.F) <= .*' '\1 <= .*'
 SKIP .* '.F <= .*' ''
 

--- a/rules/x86_qemu
+++ b/rules/x86_qemu
@@ -1,0 +1,25 @@
+# we completle ignore the following because bil is either empty,
+# either contains unknown expressions or special statements
+
+# skipping modload events
+SKIP .* '.*: .* - .*' ''
+
+# skipping context switch events
+SKIP .* 'context-switch.*' ''
+
+# skipping flags
+SKIP .* '.FLAGS.*' ''
+SKIP .* '' '.F => .*'
+SKIP .* '' '.F <= .*'
+
+# to solve differences in bitwidth
+SKIP .* '(.*) => (.*):.*' '\1 => \2:.*'
+SKIP .* '(.*) <= (.*):.*' '\1 <= \2:.*'
+
+# qemu contains some addition readings even in write operations
+SKIP MOV.* '.* => .*' ''
+SKIP CMOV.* '.* => .*' ''
+
+# Last rules means that every event should has a pair
+DENY .* '.*' ''
+DENY .* '' '.*'


### PR DESCRIPTION
Minor fixes, mainly aimed to allow `qemu` tracer usage.

`Qemu` tracer  produce  traces with particular features, that weren't taken in account before. 
So now we are able to get some positive results from verification traces from `qemu`. 
Also some rules files added. Those rules should be considered as start point to work with `qemu` traces. 
And as earlier user is welcome to specify his own rules and could use existed ones as an example.
