### PR TITLE
fix bug in evaluation of load/store exp

### DIFF
--- a/_oasis
+++ b/_oasis
@@ -1,4 +1,4 @@
-OASISFormat:  0.4
+gOASISFormat:  0.4
 Name:         bap-veri
 Version:      0.2
 Synopsis:     Bil verification tool
@@ -23,8 +23,8 @@ Library veri
                   Veri_traci
   CompiledObject: best
   Install:        true
-  NativeOpt:      -pp 'ppx-jane -dump-ast'
-  ByteOpt:        -pp 'ppx-jane -dump-ast'
+  NativeOpt:      -pp 'ppx-jane -dump-ast' -predicates ppx_driver
+  ByteOpt:        -pp 'ppx-jane -dump-ast' -predicates ppx_driver
   BuildDepends:   pcre, textutils, threads
 
 Library veri_test
@@ -32,9 +32,9 @@ Library veri_test
   Build$:         flag(tests)
   Install:        false
   CompiledObject: best
-  Modules:        Veri_test, 
-                  Veri_policy_test, 
-                  Veri_rule_test, 
+  Modules:        Veri_test,
+                  Veri_policy_test,
+                  Veri_rule_test,
                   Veri_stat_test
   BuildDepends:   bap-veri, oUnit
 

--- a/lib/veri.ml
+++ b/lib/veri.ml
@@ -253,9 +253,8 @@ class ['a] t arch dis =
       | Error er ->
         SM.update (fun c -> c#notify_error (`Lifter_error (name, er)))
       | Ok bil ->
-        let bil = Stmt.normalize ~normalize_exp:true bil in
         SM.update (fun c -> c#set_bil bil) >>= fun () ->
-        self#eval bil
+        self#eval (Stmt.normalize ~normalize_exp:true bil)
 
     method private eval_chunk chunk =
       self#update_event (Value.create Event.pc_update (Chunk.addr chunk)) >>= fun () ->

--- a/lib/veri.mli
+++ b/lib/veri.mli
@@ -22,10 +22,9 @@ class context: Veri_stat.t -> Veri_policy.t -> Trace.t -> object('s)
     method events : Value.Set.t
     method reports : Veri_report.t stream
     method register_event : Trace.event -> 's
-    method discard_event : (Trace.event -> bool) -> 's
     method notify_error: Veri_error.t -> 's
     method set_bil : bil -> 's
-    method set_code : Chunk.t -> 's 
+    method set_code : Chunk.t -> 's
     method set_insn: string -> 's
     method drop_pc : 's
   end

--- a/lib/veri_report.ml
+++ b/lib/veri_report.ml
@@ -40,8 +40,9 @@ include Regular.Make(struct
       Format.fprintf fmt "%a\n%a" Veri_rule.pp rule Matched.pp matched
 
     let pp fmt t =
+      let bil = Stmt.simpl t.bil in
       Format.fprintf fmt "@[<v>%s %a@,left: %a@,right: %a@,%a@]@."
-        t.insn pp_code t.code pp_evs t.left pp_evs t.right Bil.pp t.bil;
+        t.insn pp_code t.code pp_evs t.left pp_evs t.right Bil.pp bil;
       List.iter ~f:(pp_data fmt) t.data;
       Format.print_newline ()
 

--- a/lib/veri_traci.ml
+++ b/lib/veri_traci.ml
@@ -1,3 +1,4 @@
+open Core_kernel.Std
 open Bap.Std
 open Bap_traces.Std
 
@@ -7,60 +8,65 @@ open SM.Monad_infix
 type 'a u = 'a Bil.Result.u
 type event = Trace.event
 
-let stub = fun _ -> SM.return () 
+let stub = fun _ -> SM.return ()
 
 class context trace =
  object(self:'s)
     inherit Bili.context
-    val events = Trace.read_events trace 
+    val events = Trace.read_events trace
     method next_event = match Seq.next events with
-      | None -> None 
+      | None -> None
       | Some (ev,evs) -> Some ({<events = evs; >}, ev)
 
     method with_events trace = {<events = Trace.read_events trace >}
   end
 
-let data_size mv = 
+let data_size mv =
   Word.bitwidth (Move.data mv) |> Size.of_int_opt
 
-let mem_of_arch arch = 
+let mem_of_arch arch =
   let (module T : Target) = target_of_arch arch in
   T.CPU.mem
 
-class ['a] t arch = 
-  let mem_var = mem_of_arch arch in 
+class ['a] t arch =
+  let mem_var = mem_of_arch arch in
   let mem = Bil.var mem_var in
   let endian = Arch.endian arch in
   object(self)
     constraint 'a = #context
-    inherit ['a] Bili.t
+    inherit ['a] Bili.t as super
 
-    method eval_memory_store mv = 
+    method! eval_exp exp =
+      super#eval_exp (Exp.normalize exp)
+
+    method eval_memory_store mv =
       match data_size mv with
       | None -> SM.return ()
       | Some size ->
         let addr = Bil.int (Move.cell mv) in
         let data = Bil.int (Move.data mv) in
-        self#eval_store ~mem ~addr data endian size >>= fun r ->
+        let exp = Bil.store ~mem ~addr data endian size in
+        self#eval_exp exp >>= fun r ->
         SM.update (fun c -> c#update mem_var r)
 
-    method eval_register_write mv = 
+    method eval_register_write mv =
       self#eval_move (Move.cell mv) (Bil.int (Move.data mv))
 
-    method eval_pc_update addr = 
-      SM.update (fun c -> c#with_pc (Bil.Imm addr))    
+    method eval_pc_update addr =
+      SM.update (fun c -> c#with_pc (Bil.Imm addr))
 
-    method eval_memory_load mv = 
+    method eval_memory_load mv =
       match data_size mv with
       | None -> SM.return ()
       | Some size ->
         let addr = Bil.int (Move.cell mv) in
-        self#eval_load ~mem ~addr endian size >>| ignore
+        let exp = Bil.load ~mem ~addr endian size in
+        self#eval_exp exp >>| ignore
 
-    method eval_register_read mv = 
+    method eval_register_read mv =
       self#lookup (Move.cell mv) >>| ignore
 
-    method eval_exn exn = 
+    method eval_exn exn =
       self#eval_cpuexn (Exn.number exn)
 
     method eval_event ev =
@@ -80,11 +86,11 @@ class ['a] t arch =
         case Event.modload self#eval_modload @@
         default SM.return) ev
 
-    method eval_trace trace : 'a u = 
+    method eval_trace trace : 'a u =
       SM.update (fun ctxt -> ctxt#with_events trace) >>= fun () -> self#run
 
-    method private run : 'a u = 
-      SM.get () >>= fun ctxt -> 
+    method private run : 'a u =
+      SM.get () >>= fun ctxt ->
       match ctxt#next_event with
       | None -> SM.return ()
       | Some (ctxt, ev) ->

--- a/lib/veri_traci.ml
+++ b/lib/veri_traci.ml
@@ -36,9 +36,6 @@ class ['a] t arch =
     constraint 'a = #context
     inherit ['a] Bili.t as super
 
-    method! eval_exp exp =
-      super#eval_exp (Exp.normalize exp)
-
     method eval_memory_store mv =
       match data_size mv with
       | None -> SM.return ()

--- a/rules/arm_qemu
+++ b/rules/arm_qemu
@@ -1,6 +1,9 @@
 # skipping context switch events
 SKIP .* 'context-switch.*' ''
 
+# ignore all ours unmatched reads
+SKIP .* '' '.* => .*'
+
 SKIP .* '' '.F => .*'
 SKIP .* '' '.F <= .*'
 SKIP .* '.F <= .*' ''

--- a/rules/x86
+++ b/rules/x86
@@ -1,20 +1,30 @@
-# skipping modload events
-SKIP .* '.*: .* - .*' ''
 
-# skipping context switch events
+# skipping modload and context switch events
+SKIP .* '.*: .* - .*' ''
 SKIP .* 'context-switch.*' ''
 
-# insn contains a conditional branch. As a result, in tracer, 
-# if a condition is not satisfied then the same value 
+# ignore all ours unmatched reads
+SKIP .* '' '.* => .*'
+
+# OR insn contains an unmatched read at left side,
+# e.g. when an argument is (imm -1)
+SKIP OR* '.* => .*' ''
+
+# XOR contains an unmatched read at left side when
+# operands are the same
+SKIP XOR* '.* => .*' ''
+
+# insn contains a conditional branch. As a result, in tracer,
+# if a condition is not satisfied then the same value
 # is written (the same as was read).
 SKIP CMPXCHG.* '.* <= .*' ''
 
 # LEAVE insn has additional read from RSP in our tracer
 SKIP LEAVE.* 'RSP => .*' ''
 
-# Our flags reads(writes) should be subset of tracer 
+# Our flags reads(writes) should be subset of tracer
 # reads(writes). But writes should be with same value
-SKIP .* '.F => .*' '' 
+SKIP .* '.F => .*' ''
 DENY .* '(.F) <= .*' '\1 <= .*'
 SKIP .* '.F <= .*' ''
 

--- a/rules/x86_qemu
+++ b/rules/x86_qemu
@@ -7,18 +7,52 @@ SKIP .* '.*: .* - .*' ''
 # skipping context switch events
 SKIP .* 'context-switch.*' ''
 
+# ignore all ours unmatched reads
+SKIP .* '' '.* => .*'
+
+# OR insn contains an unmatched read at left side,
+# e.g. when an argument is (imm -1)
+SKIP OR* '.* => .*' ''
+
+# XOR contains an unmatched read at left side when
+# operands are the same
+SKIP XOR* '.* => .*' ''
+
+# for some reasons qemu doesn't write to destination
+SKIP IMUL.* '' '.* <= .*'
+SKIP MUL.* '' '.* <= .*'
+SKIP DIV.* '' '.* <= .*'
+
 # skipping flags
 SKIP .* '.FLAGS.*' ''
 SKIP .* '' '.F => .*'
 SKIP .* '' '.F <= .*'
 
-# to solve differences in bitwidth
-SKIP .* '(.*) => (.*):.*' '\1 => \2:.*'
-SKIP .* '(.*) <= (.*):.*' '\1 <= \2:.*'
+# we can't rely on SHR8ri events, since in qemu there are two
+# sequential reads of source operand, e.g. RAX => 0x10; RAX => 0x1
+# so we can't figure out what exactly we should to shift.
+# And we have event mismatchig because of this, so we ignore this
+# instruction.
+SKIP SHR8ri '' ''
+
+# skip instructions, whose side effect depends on flags
+SKIP JE_1  .* .*
+SKIP JBE_1 .* .*
+SKIP JNE_1 .* .*
+SKIP JNE_4 .* .*
+
+# tracer produces wrong reads/writes when operand size
+# lesser then current mode bitwidth
+SKIP .* '(.*) <= 0x.+(.*)' '\1 <= \2'
+SKIP .* '(.*) => 0x.+(.*)' '\1 => \2'
 
 # qemu contains some addition readings even in write operations
-SKIP MOV.* '.* => .*' ''
-SKIP CMOV.* '.* => .*' ''
+SKIP .* '.* => .*' ''
+
+# tracer produces extra zero writes/reads when operands size
+# lesser then current mode bitwidth, e.g. Mov8mi
+SKIP .* '.* => 0' ''
+SKIP .* '.* <= 0' ''
 
 # Last rules means that every event should has a pair
 DENY .* '.*' ''

--- a/rules/x86_qemu
+++ b/rules/x86_qemu
@@ -51,8 +51,8 @@ SKIP .* '.* => .*' ''
 
 # tracer produces extra zero writes/reads when operands size
 # lesser then current mode bitwidth, e.g. Mov8mi
-SKIP .* '.* => 0' ''
-SKIP .* '.* <= 0' ''
+SKIP .* '.* => 0$' ''
+SKIP .* '.* <= 0$' ''
 
 # Last rules means that every event should has a pair
 DENY .* '.*' ''

--- a/src/veri_main.ml
+++ b/src/veri_main.ml
@@ -7,11 +7,11 @@ open Veri_policy
 
 module Dis = Disasm_expert.Basic
 
-let () = 
+let () =
   match Plugins.load () |> Result.all with
   | Ok plugins -> ()
   | Error (path, er) ->
-    Printf.eprintf "failed to load plugin from %s: %s" 
+    Printf.eprintf "failed to load plugin from %s: %s"
       path (Error.to_string_hum er)
 
 module Veri_options = struct
@@ -32,55 +32,55 @@ module Program (O : Opts) = struct
   open Veri_options
   open O
 
-  let read_rules fname = 
+  let read_rules fname =
     let comments = "#" in
-    let is_sensible s = 
+    let is_sensible s =
       s <> "" && not (String.is_prefix ~prefix:comments s) in
     let inc = In_channel.create fname in
     let strs = In_channel.input_lines inc in
     In_channel.close inc;
-    List.map ~f:String.strip strs 
+    List.map ~f:String.strip strs
     |> List.filter ~f:is_sensible
     |> List.map ~f:Veri_rule.of_string_err |>
-    List.filter_map ~f:(function 
+    List.filter_map ~f:(function
         | Ok r -> Some r
-        | Error er -> 
+        | Error er ->
           Format.(fprintf std_formatter "%s\n" (Error.to_string_hum er));
           None)
 
   let string_of_error = function
-    | `Protocol_error er -> 
-      Printf.sprintf "protocol error: %s" 
+    | `Protocol_error er ->
+      Printf.sprintf "protocol error: %s"
         (Info.to_string_hum (Error.to_info er))
-    | `System_error er -> 
+    | `System_error er ->
       Printf.sprintf "system error: %s" (Unix.error_message er)
     | `No_provider -> "no provider"
     | `Ambiguous_uri -> "ambiguous uri"
 
-  let default_policy = 
-    let open Veri_rule in  
+  let default_policy =
+    let open Veri_rule in
     let p = Veri_policy.(add empty (create_exn ~insn:".*" ~left:".*" deny)) in
     Veri_policy.add p (create_exn ~insn:".*" ~right:".*" deny)
 
   let make_policy = function
     | None -> default_policy
-    | Some file -> 
+    | Some file ->
       read_rules file |>
       List.fold ~f:Veri_policy.add ~init:Veri_policy.empty
 
-  let errors_stream s = 
-    let pp_result fmt report  = 
+  let errors_stream s =
+    let pp_result fmt report  =
       Format.fprintf fmt "%a" Veri_report.pp report;
       Format.print_flush () in
     ignore(Stream.subscribe s (pp_result Format.std_formatter))
-      
-  let eval_file file policy  = 
+
+  let eval_file file policy  =
     let mk_er s = Error (Error.of_string s) in
     let uri = Uri.of_string ("file:" ^ file) in
     match Trace.load uri with
-    | Error er -> 
+    | Error er ->
       Printf.sprintf "error during loading trace: %s\n" (string_of_error er) |>
-      mk_er 
+      mk_er
     | Ok trace ->
       match Dict.find (Trace.meta trace) Meta.arch with
       | None -> mk_er "trace of unknown arch"
@@ -94,33 +94,30 @@ module Program (O : Opts) = struct
             let ctxt' = Monad.State.exec (veri#eval_trace trace) ctxt in
             Ok ctxt'#stat)
 
-  let read_dir path = 
+  let read_dir path =
     let dir = Unix.opendir path in
     let fullpath file = String.concat ~sep:"/" [path; file] in
-    let is_trace file = Filename.check_suffix file ".frames" in
-    let next () = 
-      try 
+    let next () =
+      try
         Some (Unix.readdir dir)
       with End_of_file -> None in
-    let rec folddir acc = 
+    let rec folddir acc =
       match next () with
-      | Some file -> 
-        if is_trace file then folddir (fullpath file :: acc) 
-        else folddir acc 
+      | Some file -> folddir (fullpath file :: acc)
       | None -> acc in
     let files = folddir [] in
     Unix.closedir dir;
     files
 
-  let main () =   
-    let files = 
+  let main () =
+    let files =
       if Sys.is_directory options.path then (read_dir options.path)
       else [options.path] in
     let policy = make_policy options.rules in
-    let eval stats file = 
+    let eval stats file =
       Format.(fprintf std_formatter "%s@." file);
       match eval_file file policy with
-      | Error er -> 
+      | Error er ->
         Error.to_string_hum er |>
         Printf.eprintf "error in verification: %s";
         stats
@@ -140,23 +137,23 @@ module Command = struct
 
   open Cmdliner
 
-  let filename = 
-    let doc = 
-      "Input file with extension .frames of directory with .frames files" in 
+  let filename =
+    let doc =
+      "Input trace file or directory with trace files" in
     Arg.(required & pos 0 (some string) None & info [] ~doc ~docv:"FILE | DIR")
 
   let output =
     let doc = "File to output results" in
     Arg.(value & opt (some string) None & info ["output"] ~docv:"FILE" ~doc)
-      
+
   let rules =
     let doc = "File with policy description" in
     Arg.(value & opt (some non_dir_file) None & info ["rules"] ~docv:"FILE" ~doc)
 
   let make_flag ~doc ~name = Arg.(value & flag & info [name] ~doc)
 
-  let show_errors = 
-    make_flag ~name:"show-errors" 
+  let show_errors =
+    make_flag ~name:"show-errors"
       ~doc:"Show detailed information about BIL errors"
 
   let show_stat = make_flag ~name:"show-stat" ~doc:"Show verification statistic"
@@ -170,27 +167,27 @@ module Command = struct
     ] in
     Term.info "veri" ~doc ~man
 
-  let create a b c d e = Veri_options.Fields.create a b c d e 
+  let create a b c d e = Veri_options.Fields.create a b c d e
 
-  let run_t = 
+  let run_t =
     Term.(const create $ rules $ show_errors $ show_stat $ filename $ output)
 
-  let filter_argv argv = 
+  let filter_argv argv =
     let known_passes = Project.passes () |> List.map ~f:Project.Pass.name in
     let known_plugins =  Plugins.list () |> List.map ~f:Plugin.name in
     let known_names = known_passes @ known_plugins in
     let prefixes = List.map known_names  ~f:(fun name -> "--" ^ name) in
     let is_prefix str prefix = String.is_prefix ~prefix str in
-    let is_others opt = 
+    let is_others opt =
       is_prefix opt "--" && List.exists ~f:(fun p -> is_prefix opt p) prefixes in
-    List.fold ~init:([], false) ~f:(fun (acc, drop) opt -> 
+    List.fold ~init:([], false) ~f:(fun (acc, drop) opt ->
         if drop then acc, false
         else
-        if is_others opt then acc, not (String.mem opt '=') 
-        else opt :: acc, false) (Array.to_list argv) |> 
+        if is_others opt then acc, not (String.mem opt '=')
+        else opt :: acc, false) (Array.to_list argv) |>
     fst |> List.rev |> Array.of_list
 
-  let parse argv = 
+  let parse argv =
     let argv = filter_argv argv in
     match Term.eval ~argv (run_t, info) ~catch:false with
     | `Ok opts -> opts
@@ -207,4 +204,3 @@ let start options =
   Program.main ()
 
 let () = start (Command.parse Sys.argv)
-


### PR DESCRIPTION
Previously a size of store/load operations wasn't taken into account properly, e.g. loading of one byte could be led to a loading of 4 bytes.
This PR fixes this problem.