### PR TITLE
added opam file for tests

### DIFF
--- a/opam/opam
+++ b/opam/opam
@@ -1,0 +1,35 @@
+opam-version: "1.2"
+name: "bap-veri"
+version: "master"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap-veri/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap-veri/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap-veri/"
+license: "MIT"
+
+build: [
+  ["oasis" "setup"]
+  ["./configure" "--prefix=%{prefix}%"]
+  [make]
+]
+
+install: [[make "install"]]
+
+remove: [
+  ["ocamlfind" "remove" "bap-veri"]
+  ["rm" "-f" "%{bin}%/bap-veri"]
+]
+
+depends: [
+    "bap"
+    "cmdliner"
+    "oasis"       {build}
+    "ounit"
+    "pcre"
+    "core"        {>= "v0.9.1"}
+    "textutils"
+    "uri"
+]
+
+available: [ocaml-version >= "4.02.3"]


### PR DESCRIPTION
Added opam file, so tests on travis in `bap` and `bap-testsuite` repositories
will able to pin and install bap-veri