### PR TITLE
produces no move events on conditional writes with false predicates

### DIFF
--- a/lib/veri_report.ml
+++ b/lib/veri_report.ml
@@ -28,7 +28,7 @@ include Regular.Make(struct
 
     let pp_code fmt s =
       let pp fmt s =
-        String.iter ~f:(fun c -> Format.fprintf fmt "%X " (Char.to_int c)) s in
+        String.iter ~f:(fun c -> Format.fprintf fmt "%02X " (Char.to_int c)) s in
       Format.fprintf fmt "@[<h>%a@]" pp s
 
     let pp_evs fmt evs =
@@ -41,7 +41,7 @@ include Regular.Make(struct
 
     let pp fmt t =
       let bil = Stmt.simpl t.bil in
-      Format.fprintf fmt "@[<v>%s %a@,left: %a@,right: %a@,%a@]@."
+      Format.fprintf fmt "@[<v>%s %a@,left:  %a@,right: %a@,%a@]@."
         t.insn pp_code t.code pp_evs t.left pp_evs t.right Bil.pp bil;
       List.iter ~f:(pp_data fmt) t.data;
       Format.print_newline ()

--- a/plugin/veri_bil.ml
+++ b/plugin/veri_bil.ml
@@ -47,8 +47,9 @@ let make_policy = function
     List.fold ~f:Veri_policy.add ~init:Veri_policy.empty
 
 let errors_stream s =
+  let hline = String.make 72 '=' in
   let pp_result fmt report  =
-    Format.fprintf fmt "%a" Veri_report.pp report;
+    Format.fprintf fmt "%s@\n%a" hline Veri_report.pp report;
     Format.print_flush () in
   ignore(Stream.subscribe s (pp_result Format.std_formatter) : Stream.id)
 
@@ -145,7 +146,7 @@ let features_used = [
 ]
 
 let _ = (Extension.Command.(begin
-      declare ~doc:man "veri"
-        ~requires:features_used
-        (args $input $rules $output $show_errors $show_stat)
-    end) @@ main : unit)
+    declare ~doc:man "veri"
+      ~requires:features_used
+      (args $input $rules $output $show_errors $show_stat)
+  end) @@ main : unit)


### PR DESCRIPTION
We represent conditional writes as `r := if c then x else r` so that if `c` is false the contents of `r` doesn't change. However, it was producing a write event that was triggering a false event mismatching. To prevent this, we check on each update that the new value has a different id and do not emit any events if they are the same.

Also, improves some pretty-printing functions to make the output of the error log more readable and easier to use with bap mc.