### PR TITLE
adds rules to ignore calls to the kernel-provided user helpers

### DIFF
--- a/rules/arm_qemu
+++ b/rules/arm_qemu
@@ -12,6 +12,21 @@ SKIP .* 'GE <= .*' ''
 
 SKIP .* 'PC => .*' ''
 
+## Kernel-provided User Helpers
+# See https://www.kernel.org/doc/Documentation/arm/kernel_user_helpers.txt
+
+# kuser_helper_version
+SKIP .* 'pc-update: .*' 'pc-update: 0xFFFF0FFC'
+# kuser_get_tls
+SKIP .* 'pc-update: .*' 'pc-update: 0xFFFF0FE0'
+# kuser_cmpxchg
+SKIP .* 'pc-update: .*' 'pc-update: 0xFFFF0FC0'
+# kuser_memory_barrier
+SKIP .* 'pc-update: .*' 'pc-update: 0xFFFF0FA0'
+# kuser_cmpxchg64
+SKIP .* 'pc-update: .*' 'pc-update: 0xFFFF0F60'
+
+
 # Last rules means that every event should has a pair
 DENY .* '.*' ''
 DENY .* '' '.*'


### PR DESCRIPTION
In ARM you can call to the specific addresses for kernel-provided intrinisics. When we compare traces those intrinsics are invisible to us, and we just see an immediate jump to LR, which triggers a mismatch. We explicitly specify the list of known kuser helpers in the rules file.